### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/app/src/main/java/com/suyashsrijan/forcedoze/AboutAppActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/AboutAppActivity.java
@@ -37,6 +37,8 @@ public class AboutAppActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/DozeBatteryConsumption.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/DozeBatteryConsumption.java
@@ -55,6 +55,8 @@ public class DozeBatteryConsumption extends AppCompatActivity {
             case R.id.action_clear_stats:
                 clearStats();
                 break;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/DozeBatteryStatsActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/DozeBatteryStatsActivity.java
@@ -149,6 +149,8 @@ public class DozeBatteryStatsActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/DozeStatsActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/DozeStatsActivity.java
@@ -77,6 +77,8 @@ public class DozeStatsActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/LogActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/LogActivity.java
@@ -76,6 +76,8 @@ public class LogActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/MainActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/MainActivity.java
@@ -247,6 +247,8 @@ public class MainActivity extends AppCompatActivity implements CompoundButton.On
             case R.id.action_doze_more_info:
                 showMoreInfoDialog();
                 break;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/SettingsActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/SettingsActivity.java
@@ -64,6 +64,8 @@ public class SettingsActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/TaskerBroadcastsActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/TaskerBroadcastsActivity.java
@@ -52,6 +52,8 @@ public class TaskerBroadcastsActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/WhitelistApps.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/WhitelistApps.java
@@ -106,6 +106,8 @@ public class WhitelistApps extends AppCompatActivity {
                             }
                         }).show();
                 break;*/
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/suyashsrijan/forcedoze/WhitelistAppsActivity.java
+++ b/app/src/main/java/com/suyashsrijan/forcedoze/WhitelistAppsActivity.java
@@ -93,6 +93,8 @@ public class WhitelistAppsActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat